### PR TITLE
Preflight OPTIONS request fix

### DIFF
--- a/R/middleware_cors.R
+++ b/R/middleware_cors.R
@@ -39,13 +39,12 @@ cors<-function(
 
   func<-function(req, res, err){
 
-    if(req$method == "OPTIONS"){
-      res$set_header("Allow", allow_methods)
-      return("") # equals stop processing
-    }
-
     lapply(names(headers), function(header_name) res$set_header(header_name, headers[[header_name]]))
-    return(NULL)
+      
+    if(req$method == "OPTIONS"){
+      return("") 
+      } else
+      return(NULL)
   }
 
   add_middleware(jug, func, path=path, method=NULL)


### PR DESCRIPTION
On my basic authentication jug when doing a GET request, Chrome doesa preflight options request which results in a CORS error (Allow-Cross-Origin and other header errors).

This fix creates the headers for all requests including an OPTIONS request but stop execution for when it is an Options request